### PR TITLE
DM-31505: Update to ignore reference stars in E_gray computation

### DIFF
--- a/fgcm/_version.py
+++ b/fgcm/_version.py
@@ -1,3 +1,3 @@
-__version__ = '3.6.6'
+__version__ = '3.6.7'
 
 __version_info__ = __version__.split('.')

--- a/fgcm/fgcmStars.py
+++ b/fgcm/fgcmStars.py
@@ -1404,7 +1404,7 @@ class FgcmStars(object):
         gdMeanStar, gdMeanBand = np.where(objMagStdMean[goodStars, :] < 90.0)
         objMagStdMean[goodStars[gdMeanStar], gdMeanBand] -= deltaAbsOffset[gdMeanBand]
 
-    def computeEGray(self, goodObs, ignoreRef=False, onlyObsErr=False):
+    def computeEGray(self, goodObs, ignoreRef=True, onlyObsErr=False):
         """
         Compute the delta-mag between the observed and true value (EGray) for a set of
         observations (goodObs).
@@ -1417,7 +1417,7 @@ class FgcmStars(object):
         ----------
         goodObs: `np.array`
            Array of indices of good observations
-        ignoreRef: `bool`, default=False
+        ignoreRef: `bool`, default=True
            Ignore reference stars.
         onlyObsErr: `bool`, default=False
            Only use the observational error (for non-ref stars)


### PR DESCRIPTION
Originally the default was to use reference stars when computing per-exposure residuals.  It turns out that this leads to inconsistent solutions and makes the calibration more susceptible to outliers.