### PR TITLE
DM-40555: Skip filters in look-up table that are not in the band list.

### DIFF
--- a/fgcm/_version.py
+++ b/fgcm/_version.py
@@ -1,3 +1,3 @@
-__version__ = '3.10.1'
+__version__ = '3.10.2'
 
 __version_info__ = __version__.split('.')

--- a/fgcm/fgcmStars.py
+++ b/fgcm/fgcmStars.py
@@ -485,6 +485,10 @@ class FgcmStars(object):
 
         # First, we have the filterNames
         for filterIndex,filterName in enumerate(self.lutFilterNames):
+            if self.filterToBand[filterName] not in self.bands:
+                # This LUT filter is not in the list of bands; we can skip it.
+                continue
+
             try:
                 bandIndex = self.bands.index(self.filterToBand[filterName])
             except KeyError:


### PR DESCRIPTION
This allows a look-up table that has a more complete set of filters to be used with a subset.